### PR TITLE
feat: add trip type selection page

### DIFF
--- a/frontend/src/components/trip/start.tsx
+++ b/frontend/src/components/trip/start.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useState } from 'react';
 import { DotLottieReact } from '@lottiefiles/dotlottie-react';
 import { Card } from '@/components/ui/card';
+import { Link } from 'react-router-dom';
 
 export default function Start() {
   const [hoverCreate, setHoverCreate] = useState(false);
@@ -72,9 +73,11 @@ export default function Start() {
                   <p className="mt-2 text-sm text-muted-foreground">
                     Start planning your next adventure from scratch
                   </p>
-                  <Button className="w-full mt-4" size="lg">
-                    Create Trip
-                  </Button>
+                  <Link to="/trip/new">
+                    <Button className="w-full mt-4" size="lg">
+                      Create Trip
+                    </Button>
+                  </Link>
                 </div>
               </Card>
             </motion.div>

--- a/frontend/src/components/trip/trip-type.tsx
+++ b/frontend/src/components/trip/trip-type.tsx
@@ -1,0 +1,184 @@
+import type React from 'react';
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Lock,
+  Users,
+  ArrowRight,
+  Globe,
+  UserPlus,
+  MessageSquare,
+  Calendar,
+  Map,
+  CheckCircle2,
+  ArrowLeft,
+  Clock,
+  Compass,
+  Share2,
+  UserCheck,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Link } from 'react-router-dom';
+
+export default function TripType() {
+  const navigate = useNavigate();
+  const [selectedOption, setSelectedOption] = useState<
+    'private' | 'public' | null
+  >(null);
+
+  const handleContinue = () => {
+    if (selectedOption) {
+      navigate('/trip/new');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-secondary/5 pb-20">
+      <div className="container max-w-4xl mx-auto px-4 py-8">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold mb-2">Create Your New Trip</h1>
+          <p className="text-muted-foreground">
+            Choose whether you want to plan a trip with friends or create a trip
+            for others to join
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-10">
+          <Card
+            className={`h-full cursor-pointer transition-all duration-300 hover:shadow-md ${
+              selectedOption === 'private'
+                ? 'border-primary ring-2 ring-primary/20'
+                : 'hover:border-primary/50'
+            }`}
+            onClick={() => setSelectedOption('private')}
+          >
+            <CardContent className="p-6 h-full flex flex-col">
+              <div className="flex items-center mb-4">
+                <div className="bg-primary/10 p-3 rounded-full mr-3">
+                  <Users className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-lg">Private Trip</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Plan a trip with your friends
+                  </p>
+                </div>
+                {selectedOption === 'private' && (
+                  <CheckCircle2 className="ml-auto text-primary h-6 w-6" />
+                )}
+              </div>
+
+              <div className="space-y-4 flex-grow">
+                <FeatureItem
+                  icon={<UserPlus className="h-4 w-4 text-green-500" />}
+                  text="Invite friends to plan the trip together"
+                />
+                <FeatureItem
+                  icon={<Calendar className="h-4 w-4 text-green-500" />}
+                  text="Collaborate on dates and itinerary"
+                />
+                <FeatureItem
+                  icon={<MessageSquare className="h-4 w-4 text-green-500" />}
+                  text="Group chat and decision making"
+                />
+                <FeatureItem
+                  icon={<Map className="h-4 w-4 text-green-500" />}
+                  text="Build your adventure together from scratch"
+                />
+              </div>
+
+              <div className="mt-6 pt-4 border-t">
+                <div className="flex items-center">
+                  <Clock className="h-5 w-5 text-muted-foreground mr-2" />
+                  <span className="text-sm">
+                    Perfect for planning upcoming trips with friends
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card
+            className={`h-full cursor-pointer transition-all duration-300 hover:shadow-md ${
+              selectedOption === 'public'
+                ? 'border-primary ring-2 ring-primary/20'
+                : 'hover:border-primary/50'
+            }`}
+            onClick={() => setSelectedOption('public')}
+          >
+            <CardContent className="p-6 h-full flex flex-col">
+              <div className="flex items-center mb-4">
+                <div className="bg-secondary/20 p-3 rounded-full mr-3">
+                  <Globe className="h-6 w-6 text-secondary" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-lg">Public Trip</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Create a trip for others to join
+                  </p>
+                </div>
+                {selectedOption === 'public' && (
+                  <CheckCircle2 className="ml-auto text-primary h-6 w-6" />
+                )}
+              </div>
+
+              <div className="space-y-4 flex-grow">
+                <FeatureItem
+                  icon={<Compass className="h-4 w-4 text-blue-500" />}
+                  text="Plan the entire trip from A to Z yourself"
+                />
+                <FeatureItem
+                  icon={<Share2 className="h-4 w-4 text-blue-500" />}
+                  text="Post your completed trip plan publicly"
+                />
+                <FeatureItem
+                  icon={<UserCheck className="h-4 w-4 text-blue-500" />}
+                  text="Allow others to join your planned adventure"
+                />
+                <FeatureItem
+                  icon={<Lock className="h-4 w-4 text-blue-500" />}
+                  text="Control who can join with approval settings"
+                />
+              </div>
+
+              <div className="mt-6 pt-4 border-t">
+                <div className="flex items-center">
+                  <Users className="h-5 w-5 text-muted-foreground mr-2" />
+                  <span className="text-sm">
+                    Great for trip organizers and social travelers
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex justify-between">
+          <Link to="/trip">
+            <Button variant="outline">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back
+            </Button>
+          </Link>
+
+          <Button disabled={!selectedOption} onClick={handleContinue}>
+            Continue
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FeatureItem({ icon, text }: { icon: React.ReactNode; text: string }) {
+  return (
+    <div className="flex items-start">
+      <div className="mt-0.5 mr-3">{icon}</div>
+      <span className="text-sm">{text}</span>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -20,6 +20,7 @@ import NotificationsPage from '@/pages/notifications';
 import SettingsPage from '@/pages/settings';
 import FriendsPage from '@/pages/friends';
 import ProfileSettingsPage from '@/pages/settings/profile';
+import TripTypePage from '@/pages/trip/new';
 import { Toaster } from '@/components/ui/toaster';
 
 const protectedLoginLoader = async () => {
@@ -49,6 +50,10 @@ const router = createBrowserRouter([
       {
         path: '/trip',
         element: <StartTripPage />,
+      },
+      {
+        path: '/trip/new',
+        element: <TripTypePage />,
       },
       {
         path: '/notifications',

--- a/frontend/src/pages/trip/new/index.tsx
+++ b/frontend/src/pages/trip/new/index.tsx
@@ -1,0 +1,5 @@
+import TripType from '@/components/trip/trip-type.tsx';
+
+export default function TripTypePage() {
+  return <TripType />;
+}


### PR DESCRIPTION
This pull request introduces new functionality for creating trips, including the ability to choose between private and public trips. It also includes some minor adjustments in the component structure and routing.

New functionality for trip creation:

* [`frontend/src/components/trip/trip-type.tsx`](diffhunk://#diff-188f89f96398fd18de6aa6395dcc6b2805d59f5996279fb84a7df528fc8034c4R1-R184): Added a new component `TripType` that allows users to select between creating a private or public trip, with corresponding features and options.

Routing updates:

* [`frontend/src/main.tsx`](diffhunk://#diff-f687de21d327881cdf3acf58a166c47675d7a332c21b0dc7154f751a1b5f7bb0R54-R57): Added `TripTypePage` to the routing configuration, enabling navigation to the new trip creation page.
* [`frontend/src/pages/trip/new/index.tsx`](diffhunk://#diff-8cd85e43acd862c3880a82e761f016bd242d89329e5d3e89763a4ebb63da6047R1-R5): Created a new page component `TripTypePage` that renders the `TripType` component.

Minor adjustments:

* [`frontend/src/components/trip/start.tsx`](diffhunk://#diff-5536c0347a58d281ef73887a6dc9d338c4a7dd1a075d32d1aa356738f7ab7964R76-R80): Wrapped the "Create Trip" button in a `Link` component to navigate to the new trip creation page.
* [`frontend/src/main.tsx`](diffhunk://#diff-f687de21d327881cdf3acf58a166c47675d7a332c21b0dc7154f751a1b5f7bb0R23): Imported the `TripTypePage` component.