### PR TITLE
feat: no trips handling

### DIFF
--- a/frontend/src/components/layout/layout.tsx
+++ b/frontend/src/components/layout/layout.tsx
@@ -15,13 +15,28 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { motion } from 'framer-motion';
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Separator } from '@/components/ui/separator';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate();
   const isMobile = useIsMobile();
   const location = useLocation();
   const [scrolled, setScrolled] = useState(false);
   const [pageTitle, setPageTitle] = useState('Home');
+
+  // dummy useEffect for demo in future we will change it with real stuff ;P
+  //TODO: mati my favorite backend engineer will do it
+  useEffect(() => {
+    const checkTrips = async () => {
+      const hasTrips = true;
+      if (!hasTrips && location.pathname === '/') {
+        navigate('/trip');
+      }
+    };
+
+    checkTrips();
+  }, [location, navigate]);
 
   useEffect(() => {
     const path = location.pathname;

--- a/frontend/src/components/navigation/app-sidebar.tsx
+++ b/frontend/src/components/navigation/app-sidebar.tsx
@@ -162,20 +162,23 @@ const data = {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { isDarkMode, toggleDarkMode } = useDarkMode();
+  const hasTrips = data.trips.length > 0;
 
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <TripSwitcher trips={data.trips} />
+        <TripSwitcher trips={data.trips} hasTrips={hasTrips} />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
-        <SidebarGroup>
-          <SidebarGroupLabel>Trip Companions</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <TripCompanions companions={data.companions} />
-          </SidebarGroupContent>
-        </SidebarGroup>{' '}
+        <NavMain items={data.navMain} hasTrips={hasTrips} />
+        {hasTrips && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Trip Companions</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <TripCompanions companions={data.companions} />
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>

--- a/frontend/src/components/navigation/nav-main.tsx
+++ b/frontend/src/components/navigation/nav-main.tsx
@@ -17,9 +17,11 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from '@/components/ui/sidebar.tsx';
+import { cn } from '@/lib/utils';
 
 export function NavMain({
   items,
+  hasTrips = true,
 }: {
   items: {
     title: string;
@@ -31,43 +33,52 @@ export function NavMain({
       url: string;
     }[];
   }[];
+  hasTrips?: boolean;
 }) {
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Trip</SidebarGroupLabel>
-      <SidebarMenu>
-        {items.map((item) => (
-          <Collapsible
-            key={item.title}
-            asChild
-            defaultOpen={item.isActive}
-            className="group/collapsible"
-          >
-            <SidebarMenuItem>
-              <CollapsibleTrigger asChild>
-                <SidebarMenuButton tooltip={item.title}>
-                  {item.icon && <item.icon />}
-                  <span>{item.title}</span>
-                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-                </SidebarMenuButton>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <SidebarMenuSub>
-                  {item.items?.map((subItem) => (
-                    <SidebarMenuSubItem key={subItem.title}>
-                      <SidebarMenuSubButton asChild>
-                        <a href={subItem.url}>
-                          <span>{subItem.title}</span>
-                        </a>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  ))}
-                </SidebarMenuSub>
-              </CollapsibleContent>
-            </SidebarMenuItem>
-          </Collapsible>
-        ))}
-      </SidebarMenu>
+      <div
+        className={cn(
+          hasTrips
+            ? ''
+            : 'opacity-50 pointer-events-none filter blur-[2px] select-none',
+        )}
+      >
+        <SidebarMenu>
+          {items.map((item) => (
+            <Collapsible
+              key={item.title}
+              asChild
+              defaultOpen={item.isActive}
+              className="group/collapsible"
+            >
+              <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuButton tooltip={item.title}>
+                    {item.icon && <item.icon />}
+                    <span>{item.title}</span>
+                    <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                  </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <SidebarMenuSub>
+                    {item.items?.map((subItem) => (
+                      <SidebarMenuSubItem key={subItem.title}>
+                        <SidebarMenuSubButton asChild>
+                          <a href={subItem.url}>
+                            <span>{subItem.title}</span>
+                          </a>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ))}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+          ))}
+        </SidebarMenu>
+      </div>
     </SidebarGroup>
   );
 }

--- a/frontend/src/components/navigation/trip-switcher.tsx
+++ b/frontend/src/components/navigation/trip-switcher.tsx
@@ -1,7 +1,5 @@
-'use client';
-
 import * as React from 'react';
-import { ChevronsUpDown, Plus } from 'lucide-react';
+import { ChevronsUpDown, Plus, MapPin, AlertCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -22,15 +20,19 @@ import {
 
 export function TripSwitcher({
   trips,
+  hasTrips,
 }: {
   trips: {
     name: string;
     logo: React.ElementType;
     dates: string;
   }[];
+  hasTrips: boolean;
 }) {
   const { isMobile } = useSidebar();
-  const [activeTrip, setActiveTrip] = React.useState(trips[0]);
+  const [activeTrip, setActiveTrip] = React.useState(
+    hasTrips ? trips[0] : null,
+  );
 
   return (
     <SidebarMenu>
@@ -41,15 +43,33 @@ export function TripSwitcher({
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
-                <activeTrip.logo className="size-4" />
-              </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">
-                  {activeTrip.name}
-                </span>
-                <span className="truncate text-xs">{activeTrip.dates}</span>
-              </div>
+              {hasTrips ? (
+                <>
+                  <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                    {activeTrip && <activeTrip.logo className="size-4" />}
+                  </div>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold">
+                      {activeTrip?.name}
+                    </span>
+                    <span className="truncate text-xs">
+                      {activeTrip?.dates}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-amber-500/20 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400">
+                    <MapPin className="size-4" />
+                  </div>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold">No Trips Yet</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      Create your first adventure
+                    </span>
+                  </div>
+                </>
+              )}
               <ChevronsUpDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
@@ -59,35 +79,50 @@ export function TripSwitcher({
             side={isMobile ? 'bottom' : 'right'}
             sideOffset={4}
           >
-            <DropdownMenuLabel className="text-xs text-muted-foreground">
-              Your Trips
-            </DropdownMenuLabel>
-            {trips.map((trip, index) => (
-              <DropdownMenuItem
-                key={trip.name}
-                onClick={() => setActiveTrip(trip)}
-                className="gap-2 p-2"
-              >
-                <div className="flex size-6 items-center justify-center rounded-sm border">
-                  <trip.logo className="size-4 shrink-0" />
+            {hasTrips ? (
+              <>
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  Your Trips
+                </DropdownMenuLabel>
+                {trips.map((trip, index) => (
+                  <DropdownMenuItem
+                    key={trip.name}
+                    onClick={() => setActiveTrip(trip)}
+                    className="gap-2 p-2"
+                  >
+                    <div className="flex size-6 items-center justify-center rounded-sm border">
+                      <trip.logo className="size-4 shrink-0" />
+                    </div>
+                    <div className="flex flex-col">
+                      <span>{trip.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {trip.dates}
+                      </span>
+                    </div>
+                    <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                  </DropdownMenuItem>
+                ))}
+              </>
+            ) : (
+              <div className="px-4 py-3">
+                <div className="flex items-center gap-3 mb-2">
+                  <AlertCircle className="h-5 w-5 text-amber-500" />
+                  <p className="text-sm font-medium">No trips available</p>
                 </div>
-                <div className="flex flex-col">
-                  <span>{trip.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {trip.dates}
-                  </span>
-                </div>
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
-              </DropdownMenuItem>
-            ))}
+                <p className="text-xs text-muted-foreground mb-2">
+                  Start by creating your first trip to begin planning your
+                  adventure
+                </p>
+              </div>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild className="gap-2 p-2">
               <Link to="/trip">
-                <div className="flex size-6 items-center justify-center rounded-md border bg-background">
+                <div className="flex size-6 items-center justify-center rounded-md border bg-primary/10 text-primary">
                   <Plus className="size-4" />
                 </div>
-                <div className="font-medium text-muted-foreground">
-                  Plan New Trip
+                <div className="font-medium">
+                  {hasTrips ? 'Plan New Trip' : 'Create First Trip'}
                 </div>
               </Link>
             </DropdownMenuItem>


### PR DESCRIPTION
This pull request includes several changes to the `frontend/src/components` directory to enhance the user interface and improve the handling of trips in the navigation components. The most important changes include the addition of a navigation check for trips, updates to the `AppSidebar` and `NavMain` components to handle the presence of trips, and modifications to the `TripSwitcher` component to provide appropriate feedback when no trips are available.

Enhancements to trip navigation:

* [`frontend/src/components/layout/layout.tsx`](diffhunk://#diff-f4d01b3b61d9adcfcde2c533de0064d3f0fa824838f829cd193b2fb32a4b3149R18-R40): Added a `useEffect` hook to check for trips and navigate to the `/trip` page if no trips are available and the current path is `/`.

Updates to `AppSidebar` and `NavMain` components:

* [`frontend/src/components/navigation/app-sidebar.tsx`](diffhunk://#diff-b76e4cc5aa175a9605d843d6b2b974cef0f02363f0a0ebe80079929bbe27867fR165-R181): Introduced a `hasTrips` variable to conditionally render trip-related elements based on the presence of trips.
* [`frontend/src/components/navigation/nav-main.tsx`](diffhunk://#diff-e61132323c986ec79828411481f3bbd98722916477fca71897bb7920b20d942aR20-R24): Added a `hasTrips` prop to control the visibility and interactivity of trip-related menu items. [[1]](diffhunk://#diff-e61132323c986ec79828411481f3bbd98722916477fca71897bb7920b20d942aR20-R24) [[2]](diffhunk://#diff-e61132323c986ec79828411481f3bbd98722916477fca71897bb7920b20d942aR36-R47) [[3]](diffhunk://#diff-e61132323c986ec79828411481f3bbd98722916477fca71897bb7920b20d942aR81)

Modifications to `TripSwitcher` component:

* [`frontend/src/components/navigation/trip-switcher.tsx`](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2L1-R2): Updated the component to handle cases where no trips are available, displaying appropriate messages and disabling certain interactions. [[1]](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2L1-R2) [[2]](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2R23-R35) [[3]](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2R46-R72) [[4]](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2R82-R83) [[5]](diffhunk://#diff-959740bcef728a989fb2f1aee70d3e6525d006817a66301341c93963a521dbd2R105-R125)